### PR TITLE
Mac OS X bundle ant task update to copy config.properties

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -55,6 +55,7 @@
 				<exclude name="*.java" />
 			</fileset>
 		</copy>
+		<copy file="config.properties" todir="osx/Eyesleep.app/Contents/Java" />
 <!-- 		to remove icon from the dock give this cmd in a terminal and then restart the app -->
 <!-- 		defaults write /Applications/Eyesleep.app/Contents/Info LSUIElement -string 1 -->
 	</target>


### PR DESCRIPTION
This is to maintain working the bundleOSX ant task to create a beautiful Eyesleep.app package for Mac's operating system.

It simply copies the file config.properties into the Eyesleep.app/Contents/Java directory.
